### PR TITLE
fix: vercel i18n 404

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -14,7 +14,7 @@
                         </div>
                     </div>
                     <div class="hidden md:flex md:space-x-10">
-                        <a href="{{ .Site.Params.links.wiki | absURL }}" class="font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-50">Documentation</a>
+                        <a href="{{ .Site.Params.links.wiki | absURL }}" class="font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-50">{{ i18n "links.documentation" . }}</a>
                     </div>
                     <div class="hidden md:absolute md:flex md:items-center md:justify-end md:inset-y-0 md:right-0">
                         <span class="inline-flex rounded-md shadow"><a class="inline-flex items-center px-4 py-2 border border-transparent text-base leading-6 font-medium rounded-md text-green-500 bg-white dark:bg-gray-800 hover:text-green-400 focus:outline-none focus:border-green-300 focus:shadow-outline-green active:bg-gray-50 active:text-gray-700 transition duration-150 ease-in-out" href="mailto:{{ .Site.Params.social.email }}">Get in Touch</a></span>

--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,10 @@
       "HUGO_VERSION": "0.79.0",
       "NODE_ENV": "production"
     }
-  }
+  },
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/es/(.*)", "status": 404, "dest": "/es/404.html" },
+    { "src": "/(.*)",    "status": 404, "dest": "/404.html" }
+  ]
 }


### PR DESCRIPTION
This adds custom routing to the app so that `/es/(.*)` routes should fallback to `/es/404.html`.