### PR TITLE
Revert to "Deutsch"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -54,7 +54,7 @@ DefaultContentLanguage = "en"
     title = "Rocky Linux"
     weight = 5
   [languages.de]
-    languageName = "German"
+    languageName = "Deutsch"
     title = "Rocky Linux"
     weight = 6
   [languages.ru]


### PR DESCRIPTION
The PR #40 change the name of the language. This PR reverts that change.

The language name is "Deutsch" and not "German" which is the translation into Englisch of "Deutsch".