### PR TITLE
Fix Safari Zooming in When Selecting Languages

### DIFF
--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -1,6 +1,6 @@
 <title>{{ .Title }}</title>
 <meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no" />
 
 {{ $styles := resources.Get "css/main.css" }}
 {{ $styles = $styles | resources.PostCSS (dict "inlineImports" true) }}


### PR DESCRIPTION
Safari (9.0+) will zoom in when entering text in an input field or selecting an item from a dropdown. This behaviour is also shown on the site when changing language with the dropdown.
Adding `shrink-to-fit=no` to the viewport meta tag will fix this.