### PR TITLE
[New]Correcte machine and incorrect translation

### DIFF
--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -73,7 +73,7 @@ other = "zh-cn"
     other = "您的意思是\"其下游合作伙伴已改变方向\"？"
 
     [faq.q.come-in]
-    other = "那么Rocky Linux从何入手？"
+    other = "那么 Rocky Linux 的优势在哪呢"
 
   [faq.a]
     [faq.a.downstream-partner-direction]

--- a/i18n/zh-HK.toml
+++ b/i18n/zh-HK.toml
@@ -73,7 +73,7 @@ other = "zh-hk"
     other = "您的意思是\"其下游合作夥伴已改變方向\"？"
 
     [faq.q.come-in]
-    other = "那麼Rocky Linux從何入手？"
+    other = "那麽 Rocky Linux 的優勢在哪呢？"
 
   [faq.a]
     [faq.a.downstream-partner-direction]


### PR DESCRIPTION
zh-CN: So where does Rocky Linux come in? ->"那么 Rocky Linux 的优势在哪呢？"
zh-HK: So where does Rocky Linux come in? ->"那麽 Rocky Linux 的優勢在哪呢？"

I think this machine translation should be corrected.

