### PR TITLE
Translation improvements to es.toml

### DIFF
--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -62,7 +62,7 @@ other = "es"
   other = "¿Que es el proyecto Rocky Linux?"
 
   [landing.p2.content]
-  other = "Rocky Linux es un sistema operativo empresarial comunitario diseñado para ser 100% compatible con la distribución de Linux empresarial más importante de Estados Unidos ahora que su socio intermedio ha cambiado de dirección. Está en desarrollo intensivo por parte de la comunidad. Rocky Linux está dirigido por Gregory Kurtzer, fundador del proyecto CentOS. No hay ETA para un lanzamiento. Se solicita a los colaboradores que se comuniquen con las opciones de comunicación que se ofrecen en este sitio."
+  other = "Rocky Linux es un sistema operativo empresarial comunitario diseñado para ser 100% compatible con la distribución de Linux empresarial más importante de Estados Unidos ahora que su socio downstream ha cambiado de dirección. Está en desarrollo intensivo por parte de la comunidad. Rocky Linux está dirigido por Gregory Kurtzer, fundador del proyecto CentOS. No hay fecha estimada para un lanzamiento. Se solicita a los colaboradores que se comuniquen con las opciones ofrecidas en este sitio."
 
 [faq]
   [faq.title]
@@ -70,17 +70,17 @@ other = "es"
 
   [faq.q]
     [faq.q.downstream-partner-direction]
-    other = "Que significa, \"¿Su socio anterior ha cambiado de dirección?\""
+    other = "Que significa, \"¿Su socio downstream ha cambiado de dirección?\""
 
     [faq.q.come-in]
-    other = "Entonces, ¿dónde entra Rocky Linux?"
+    other = "Entonces, ¿dónde entra en juego Rocky Linux?"
 
   [faq.a]
     [faq.a.downstream-partner-direction]
-    other = "El proyecto CentOS anunció recientemente un cambio en la estrategia de CentOS. Mientras que anteriormente CentOS existía como una compilación descendente de su proveedor ascendente (recibe parches y actualizaciones después de que lo hace el proveedor ascendente), se cambiará a una compilación ascendente (probando parches y actualizaciones antes de su inclusión en el proveedor ascendente). Además, el soporte para CentOS Linux 8 se ha interrumpido, desde el 31 de mayo de 2029 hasta el 31 de diciembre de 2021."
+    other = "El proyecto CentOS anunció recientemente un cambio en la estrategia de CentOS. Mientras que anteriormente CentOS existía como una versión downstream de su proveedor upstream (recibe parches y actualizaciones tras el proveedor upstream), se cambiará a una versión upstream (probando parches y actualizaciones antes de su inclusión en el proveedor upstream). Además, el soporte para CentOS Linux 8 se ha interrumpido, desde el 31 de mayo de 2029 hasta el 31 de diciembre de 2021."
 
     [faq.a.come-in]
-    other = "Rocky Linux apunta a funcionar como una compilación descendente como lo había hecho CentOS anteriormente, construyendo versiones después de que hayan sido agregadas por el proveedor ascendente, no antes."
+    other = "Rocky Linux apunta a funcionar como una compilación downstream como lo había hecho CentOS anteriormente, construyendo versiones después de que hayan sido agregadas por el proveedor upstream, no antes."
 
 [lang]
   [lang.footer.choose-language]


### PR DESCRIPTION
- Replaced "ascendente" terminology to "upstream"
  - Corrected "intermedio"/"descendente" as "downstream"
- Changed "ETA" to "fecha estimada"
- "Build" is translated as "versión" instead of "compilación"
- A bit of redundant language was replaced, as with "opciones de comunicación"
- Reworked "come in" translation as "dónde entra en juego"