### PR TITLE
Update es.toml

### DIFF
--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -70,8 +70,8 @@ other = "es"
 
   [faq.q]
     [faq.q.downstream-partner-direction]
-    other = "Que significa, \"¿Su socio anterior ha cambiado de dirección?\""
-
+    other = "¿Qué significa que, \"su socio anterior haya cambiado de dirección?\""
+    
     [faq.q.come-in]
     other = "Entonces, ¿dónde entra Rocky Linux?"
 


### PR DESCRIPTION
Grammar correction to Spanish:
The entire question must be enclosed in question marks.
And adaptation of the verb to the past imperfect.